### PR TITLE
chore: Switch copyright to DFINITY Stiftung

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 DFINITY LLC.
+   Copyright 2023 DFINITY Stiftung.
    
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
IP needs to be owned by the parent entity, i.e. DFINITY Stiftung, and not by the subsidiary (DFINITY LLC).