### PR TITLE
fix: Update how DFX is installed in CI jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -161,7 +161,9 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          bash install-dfx.sh < <(yes Y)
+          DFXVM_INIT_YES=true bash install-dfx.sh < <(yes Y)
+          echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
+          source "$HOME/.local/share/dfx/env"
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH
@@ -193,7 +195,9 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          bash install-dfx.sh < <(yes Y)
+          DFXVM_INIT_YES=true bash install-dfx.sh < <(yes Y)
+          echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
+          source "$HOME/.local/share/dfx/env"
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH
@@ -225,7 +229,9 @@ jobs:
       - name: Install DFX
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          bash install-dfx.sh < <(yes Y)
+          DFXVM_INIT_YES=true bash install-dfx.sh < <(yes Y)
+          echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
+          source "$HOME/.local/share/dfx/env"
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH


### PR DESCRIPTION
After the introduction of `dfxvm`, the CI setup needs to be updated in how it installs dfx to work again correctly.